### PR TITLE
YALB-256: Setup Lando

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,6 @@
 
 # Ignore .env files as they are personal
 #/.env
+
+# Ingnore local lando settings. Each site will have unique values.
+.lando.local.yml

--- a/.gitignore
+++ b/.gitignore
@@ -96,5 +96,5 @@
 # Ignore .env files as they are personal
 #/.env
 
-# Ingnore local lando settings. Each site will have unique values.
+# Ignore local lando settings. Each site will have unique values.
 .lando.local.yml

--- a/.lando.local.example.yml
+++ b/.lando.local.example.yml
@@ -1,0 +1,12 @@
+# Each YaleSite property will have unique environmental variables used to
+# connect the local lando site to the remote website hosted by Pantheon.
+# Copy and rename this file to .lando.local.yml and set any site specific
+# variables and overrides.
+
+# Set a local name for this application; this can be any value.
+name: yalesites-web-property
+config:
+  # Replace the example below with the 32 alphanumeric Pantheon site UUID.
+  id: de305d54-75b4-431b-adb2-eb6b9e546014
+  # Replace the example below with the Pantheon site name.
+  site: exampledepartment-yale-edu

--- a/.lando.upstream.yml
+++ b/.lando.upstream.yml
@@ -1,0 +1,10 @@
+name: yalesites-web-property
+recipe: pantheon
+config:
+  framework: drupal8
+  # Disable the SOLR index
+  index: false
+  # Enable the VARNISH edge
+  edge: true
+  # Enable the REDIS cache
+  cache: true

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ YaleSites uses a hierarchy of Pantheon upstreams to deliver a consistent set of 
 * *Platform upstream (fork of base)*: A separate platform upstream contains any code that is particular to sites on the YaleSites platform (lowest tier) but should not be included on vendor-supported sites. Sites on the platform upstream will use the integrated composer workflow and will pull in build artifacts for the themes.
 * *Vendor supported upstream (fork of base)*: A separate upstream contains code specific to vendor-supported sites. It is possible that this upstream mirrors the base upstream but will still exist for unknown future needs.
 
-## Development
+## Upstream architecture
 
 This project follows the authoritative [drupal-recommended](https://github.com/pantheon-upstreams/drupal-recommended) repository managed by Pantheon. Updates to Pantheon scaffolding and Drupal Core may be pulled from this remote. Pantheon's [integrated composer](https://pantheon.io/docs/integrated-composer) is employed as part of a one-click continuous integration strategy.
 
@@ -20,8 +20,8 @@ Files and directories important to the structure of the upstream include:
    └─ settings.php
 ├─ .gitignore
 ├─ composer.json
-└─ pantheon.upstream.yml
-├─ README.md
+├─ pantheon.upstream.yml
+└─ README.md
 ```
 
 * `config/`: Not currently in use on this project.
@@ -31,3 +31,21 @@ Files and directories important to the structure of the upstream include:
 * `composer.json`: The composer file at the project root is for project settings and scaffolding. Vendor-supported sites or sites with emergent features may add dependencies or customizations here. Developers should avoid updating this file in the upstream.
 * `pantheon.upstream.yml`: The build_step: true directive in pantheon.upstream.yml enables the build step.
 * `README.md`: You are [here](#).
+
+## Local Development Environment
+
+This project supports development with Lando using the Pantheon recipe. Most local tooling, including Composer, Drush, Drupal console, and node applications are available through this recipe.
+
+### Requirements
+
+* [Composer](https://getcomposer.org/download/): PHP package manager. Version 2.x.
+* [Terminus](https://pantheon.io/docs/terminus): Pantheon CLI.
+* [Docker](https://docs.docker.com/install): Container system for virtualization.
+* [Lando](https://docs.lando.dev/basics/installation.html#system-requirements): Recipes and tools for Docker.
+
+### Setup
+* [Lando CA](https://docs.devwithlando.io/config/security.html): Optional certificate authority setup.
+* Public key for your machine uploaded to Pantheon.
+* Copy `.lando.local.example.yml` to `.lando.local.yml` and set the Pantheon environmental variables for the site you wish to work on.
+* Run `lando start`
+* Run `lando pull`

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This project supports development with Lando using the Pantheon recipe. Most loc
 
 ### Setup
 * [Lando CA](https://docs.devwithlando.io/config/security.html): Optional certificate authority setup.
-* Public key for your machine uploaded to Pantheon.
+* [Create a machine token](https://pantheon.io/docs/machine-tokens) and log authenticate with Terminus.
 * Copy `.lando.local.example.yml` to `.lando.local.yml` and set the Pantheon environmental variables for the site you wish to work on.
 * Run `lando start`
 * Run `lando pull`


### PR DESCRIPTION
## [YALB-256: Setup Lando](https://yaleits.atlassian.net/browse/YALB-256)

### Description of work
- Creates a lando config file for all sites using the upstream. This uses the Pantheon recipe to leverage supporing commands such to sync Pantheon environments with the local dev.
- Includes an example local lando file to help developers set site specific environmental variables.
- Adds the local lando file to gitignore
- Includes minimal changes to the README as a future ticket includes deeper contribution instructions.

### Functional testing steps:
- [ ] Clone this repo: `git clone https://github.com/yalesites-org/yalesites-upstream-base.git`
- [ ] Checkout this branch `git checkout YALB-256-lando`
- [ ] Make a file for local lando settings in the repo root named `.lando.local.yml` with the contents:
```
name: yalesites4kupstreamtest16
config:
  id: ed6c6a92-74fe-46f2-9bc5-b500b2ecc0b7
  site: yalesites4kupstreamtest16
```
- [ ] Run `lando start` to initialize the environment
- [ ] Run `lando pull --code=none --database=dev --files=none` 
- [ ] Visit the site and verify Drupal is installed. [https://yalesites4kupstreamtest16.lndo.site](https://yalesites4kupstreamtest16.lndo.site)
- [ ] Verify the site title reads "YaleSites Platform".
